### PR TITLE
Release for v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.3.2](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.3.1...v0.3.2) - 2024-11-30
+- Bump github.com/cli/go-gh/v2 from 2.11.0 to 2.11.1 by @dependabot in https://github.com/kromiii/tbls-ask-agent-slack/pull/63
+- Use statefulset and fix some bugs by @kromiii in https://github.com/kromiii/tbls-ask-agent-slack/pull/62
+- Enable Custom instruction by @kromiii in https://github.com/kromiii/tbls-ask-agent-slack/pull/65
+
 ## [v0.3.1](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.3.0...v0.3.1) - 2024-11-23
 - Add tests by @kromiii in https://github.com/kromiii/tbls-ask-agent-slack/pull/60
 


### PR DESCRIPTION
This pull request is for the next release as v0.3.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump github.com/cli/go-gh/v2 from 2.11.0 to 2.11.1 by @dependabot in https://github.com/kromiii/tbls-ask-agent-slack/pull/63
* Use statefulset and fix some bugs by @kromiii in https://github.com/kromiii/tbls-ask-agent-slack/pull/62
* Enable Custom instruction by @kromiii in https://github.com/kromiii/tbls-ask-agent-slack/pull/65


**Full Changelog**: https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.3.1...v0.3.2