### PR TITLE
update documents

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,15 +1,12 @@
 export OPENAI_API_KEY=sk-***
 export SLACK_OAUTH_TOKEN=xoxb-***
 export SLACK_APP_TOKEN=***
-export MODEL_NAME=gpt-4o
+export MODEL_NAME=gpt-4o-mini
 # Custom Instruction (optional)
 # export CUSTOM_INSTRUCTION="Always Respond in Japanese"
 # For Gemini models
 # export MODEL_NAME=gemini-1.5-flash
 # export GEMINI_API_KEY=***
-# For Google Cloud
-# export GOOGLE_CLOUD_REGION=asia-northeast1
-# export GOOGLE_APPLICATION_CREDENTIALS_JSON=$(cat /path/to/your/credentials.json)
 # For GitHub Enterprise Server
 # export GH_HOST=git.xxx.com
 # export GITHUB_ENTERPRISE_TOKEN=***

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ create-secret:
 	--from-literal=slack-oauth-token=$$SLACK_OAUTH_TOKEN \
 	--from-literal=github-token=$$GITHUB_TOKEN \
 	--from-literal=openai-api-key=$$OPENAI_API_KEY \
-	--from-literal=google-application-credentials-json="$$GOOGLE_APPLICATION_CREDENTIALS_JSON"
+	--from-literal=gemini-api-key=$$GEMINI_API_KEY
 
 build-image:
 	docker build -t tbls-ask-agent-slack:latest .

--- a/README.md
+++ b/README.md
@@ -46,15 +46,13 @@ By default, we use OpenAI models. You need to set `OPENAI_API_KEY`.
 
 * OPENAI_API_KEY: API key for OpenAI
 
-If you want to use Gemini models, you need to set either `GEMINI_API_KEY` or `GOOGLE_APPLICATION_CREDENTIALS_JSON`.
+If you want to use Gemini models, you need to set `GEMINI_API_KEY`.
 
 * GEMINI_API_KEY: API key for Gemini
-* GOOGLE_APPLICATION_CREDENTIALS_JSON: JSON key for Google Cloud
 
 ### Optional
 * GITHUB_TOKEN: Token for GitHub API (optional)
 * CUSTOM_INSTRUCTION: Custom instruciton for LLM (optional)
-* GOOGLE_CLOUD_REGION: Region for Google Cloud (optional, default: us-central1)
 * DEBUG_MODE: When set to "true", outputs prompt contents to logs (optional)
 
 ## Slack-app settings
@@ -75,7 +73,7 @@ $ cp schemas/config.yml.sample schemas/config.yml
 make server
 ```
 
-It is using socket mode for slack. You don't need to expose the server to the internet.
+This app uses socket mode for slack, so you don't need to expose the server to the internet. That means you don't need to set `SLACK_SIGNING_SECRET`.
 
 ## Deploy to k8s
 

--- a/manifests/deployment-gemini.yml
+++ b/manifests/deployment-gemini.yml
@@ -27,11 +27,11 @@ spec:
               secretKeyRef:
                 name: tbls-ask-agent-slack
                 key: slack-oauth-token
-          - name: GOOGLE_APPLICATION_CREDENTIALS_JSON
+          - name: GEMINI_API_KEY
             valueFrom:
               secretKeyRef:
                 name: tbls-ask-agent-slack
-                key: google-application-credentials-json
+                key: gemini-api-key
           - name: GITHUB_TOKEN
             valueFrom:
               secretKeyRef:
@@ -39,8 +39,6 @@ spec:
                 key: github-token
           - name: MODEL_NAME
             value: gemini-1.5-pro
-          - name: GOOGLE_CLOUD_REGION
-            value: asia-northeast1
         volumeMounts:
         - name: tbls-schemas
           mountPath: /app/schemas

--- a/manifests/deployment-openai.yml
+++ b/manifests/deployment-openai.yml
@@ -38,7 +38,7 @@ spec:
                 name: tbls-ask-agent-slack
                 key: github-token
           - name: MODEL_NAME
-            value: gpt-4o
+            value: gpt-4o-mini
         volumeMounts:
         - name: tbls-schemas
           mountPath: /app/schemas


### PR DESCRIPTION
# Remove Google Cloud Authentication and Simplify Gemini API Key Integration

## Changes
1. Remove Google Cloud related configurations
   - Remove `GOOGLE_APPLICATION_CREDENTIALS_JSON`
   - Remove `GOOGLE_CLOUD_REGION`

2. Simplify Gemini authentication
   - Switch to Gemini API key only authentication
   - Update related environment variables and Kubernetes Secrets

3. Update default model
   - Change OpenAI model from `gpt-4o` to `gpt-4o-mini`

4. Documentation updates
   - Update authentication section in README
   - Clarify Slack app configuration (add note about `SLACK_SIGNING_SECRET` not being required)

## Reasons for Changes
- Simplify Gemini API authentication for more intuitive setup
- Remove unnecessary Google Cloud dependencies
- Optimize costs by using a lighter OpenAI model

## Impact
- Environments using existing Google Cloud authentication will need to migrate to Gemini API key
- Environments using OpenAI model will be updated to new model (gpt-4o-mini)