### PR TITLE
Release for v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.5.6](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.5...v0.5.6) - 2026-06-20
+
+- Bump github.com/slack-go/slack from 0.25.0 to 0.26.0 in the all-dependencies group by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/131
+- Bump go.mongodb.org/mongo-driver from 1.17.4 to 1.17.7 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/133
+
 ## [v0.5.5](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.4...v0.5.5) - 2026-06-09
 
 - Bump github.com/slack-go/slack from 0.24.0 to 0.25.0 in the all-dependencies group by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/129


### PR DESCRIPTION
This pull request is for the next release as v0.5.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.5.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump github.com/slack-go/slack from 0.25.0 to 0.26.0 in the all-dependencies group by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/131
* Bump go.mongodb.org/mongo-driver from 1.17.4 to 1.17.7 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/133


**Full Changelog**: https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.5...tagpr-from-v0.5.5