### PR TITLE
Release for v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.5.9](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.8...v0.5.9) - 2026-07-05
+
+- Bump golang.org/x/net from 0.48.0 to 0.55.0 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/138
+
 ## [v0.5.8](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.7...v0.5.8) - 2026-06-30
 
 - Bump github.com/slack-go/slack from 0.26.0 to 0.27.0 in the all-dependencies group by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/136


### PR DESCRIPTION
This pull request is for the next release as v0.5.9 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.9 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.5.8" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump golang.org/x/net from 0.48.0 to 0.55.0 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/138


**Full Changelog**: https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.8...tagpr-from-v0.5.8