### PR TITLE
Release for v0.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.5.12](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.11...v0.5.12) - 2026-07-15
+
+- Bump github.com/k1LoW/tbls-ask from 0.6.9 to 0.6.10 in the all-dependencies group by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/144
+- fix: resolve golangci-lint errors and test data race by @kromiii in https://github.com/kromiii/tbls-ask-agent-slack/pull/146
+
 ## [v0.5.11](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.10...v0.5.11) - 2026-07-13
 
 - Bump golang.org/x/crypto from 0.51.0 to 0.52.0 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/142


### PR DESCRIPTION
This pull request is for the next release as v0.5.12 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.12 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.5.11" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump github.com/k1LoW/tbls-ask from 0.6.9 to 0.6.10 in the all-dependencies group by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/144
* fix: resolve golangci-lint errors and test data race by @kromiii in https://github.com/kromiii/tbls-ask-agent-slack/pull/146


**Full Changelog**: https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.11...tagpr-from-v0.5.11