### PR TITLE
fix: resolve golangci-lint errors and test data race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Run lint
         uses: reviewdog/action-golangci-lint@v2

--- a/client/client.go
+++ b/client/client.go
@@ -60,12 +60,12 @@ func buildSchemaPrompt(schemas []*SchemaInfo) (schemaPrompt string, systemPrompt
 	if len(schemas) == 1 {
 		loadedSchema, err := schema.Load(schemas[0].Path, schema.Options{})
 		if err != nil {
-			return "", "", fmt.Errorf("Failed to load schema: %s", err.Error())
+			return "", "", fmt.Errorf("failed to load schema: %s", err.Error())
 		}
 
 		schemaPrompt, err := prompt.Generate(loadedSchema)
 		if err != nil {
-			return "", "", fmt.Errorf("Failed to generate schema prompt: %v", err)
+			return "", "", fmt.Errorf("failed to generate schema prompt: %v", err)
 		}
 
 		return schemaPrompt, "You are a database expert. You are given a database schema with chat histories. Answer the users' question based on the following schema.", nil
@@ -75,12 +75,12 @@ func buildSchemaPrompt(schemas []*SchemaInfo) (schemaPrompt string, systemPrompt
 	for _, s := range schemas {
 		loadedSchema, err := schema.Load(s.Path, schema.Options{})
 		if err != nil {
-			return "", "", fmt.Errorf("Failed to load schema %s: %v", s.Name, err)
+			return "", "", fmt.Errorf("failed to load schema %s: %v", s.Name, err)
 		}
 
 		sp, err := prompt.Generate(loadedSchema)
 		if err != nil {
-			return "", "", fmt.Errorf("Failed to generate schema prompt for %s: %v", s.Name, err)
+			return "", "", fmt.Errorf("failed to generate schema prompt for %s: %v", s.Name, err)
 		}
 
 		schemaPrompts = append(schemaPrompts, fmt.Sprintf("=== Database: %s ===\n%s", s.Name, sp))

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -35,7 +35,7 @@ func TestAsk(t *testing.T) {
 		t.Error("Unexpected 'No messages found' result")
 	}
 
-	if result == "Failed to load schema: " {
+	if result == "failed to load schema: " {
 		t.Error("Failed to load schema")
 	}
 }
@@ -70,7 +70,7 @@ func TestAskWithInvalidSchema(t *testing.T) {
 
 	result := Ask(messages, name, path, botUserID, model)
 
-	expectedPrefix := "Failed to load schema: failed to analyze schema: "
+	expectedPrefix := "failed to load schema: failed to analyze schema: "
 	if !strings.HasPrefix(result, expectedPrefix) {
 		t.Errorf("Expected result to start with '%s', got: %s", expectedPrefix, result)
 	}
@@ -153,7 +153,7 @@ func TestAskWithSchemasMultipleSchemasInvalidPath(t *testing.T) {
 
 	result := AskWithSchemas(messages, schemas, botUserID, model)
 
-	expectedPrefix := "Failed to load schema db1: failed to analyze schema: "
+	expectedPrefix := "failed to load schema db1: failed to analyze schema: "
 	if !strings.HasPrefix(result, expectedPrefix) {
 		t.Errorf("Expected result to start with '%s', got: %s", expectedPrefix, result)
 	}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -36,7 +36,9 @@ func Run() {
 				if !ok {
 					continue
 				}
-				client.Ack(*socketEvent.Request)
+				if err := client.Ack(*socketEvent.Request); err != nil {
+					log.Print(err)
+				}
 				err := slackHandler.HandleCallBackEvent(event, path)
 				if err != nil {
 					log.Print(err)
@@ -46,7 +48,9 @@ func Run() {
 				if !ok {
 					continue
 				}
-				client.Ack(*socketEvent.Request)
+				if err := client.Ack(*socketEvent.Request); err != nil {
+					log.Print(err)
+				}
 				err := slackHandler.HandleInteractionCallback(interaction)
 				if err != nil {
 					log.Print(err)

--- a/slackhandler/slackhandler_test.go
+++ b/slackhandler/slackhandler_test.go
@@ -278,8 +278,6 @@ func TestCreateSchemaOptions(t *testing.T) {
 }
 
 func TestHandleAllSchemaSelection(t *testing.T) {
-	t.Parallel()
-
 	mockAPI := new(MockSlackAPI)
 	handler := NewSlackHandler(mockAPI)
 	handler.configPath = "./schemas/config.yml"


### PR DESCRIPTION
- fix(client): lowercase error strings to satisfy staticcheck ST1005
- fix(server): handle return value of client.Ack() for errcheck
- fix(test): remove t.Parallel() from TestHandleAllSchemaSelection to prevent data race on global fileLoader variable