### PR TITLE
Release for v0.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.5.16](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.15...v0.5.16) - 2026-09-03
+
+- Bump google.golang.org/grpc from 1.79.3 to 1.83.1 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/153
+- Bump github.com/apache/thrift from 0.23.0 to 0.24.0 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/154
+
 ## [v0.5.15](https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.14...v0.5.15) - 2026-08-26
 
 - Bump the all-dependencies group with 2 updates by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/151


### PR DESCRIPTION
This pull request is for the next release as v0.5.16 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.16 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.5.15" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump google.golang.org/grpc from 1.79.3 to 1.83.1 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/153
* Bump github.com/apache/thrift from 0.23.0 to 0.24.0 by @dependabot[bot] in https://github.com/kromiii/tbls-ask-agent-slack/pull/154


**Full Changelog**: https://github.com/kromiii/tbls-ask-agent-slack/compare/v0.5.15...tagpr-from-v0.5.15